### PR TITLE
Expand default board to 48 spaces

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The CashFlow Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# CashFlow
+# CashFlow Game Engine
+
+This repository contains a very small Python implementation of a game engine
+for a board-game clone inspired by Robert Kiyosaki's **Cashflow**.
+
+The engine is located in the `cashflow` package. A simple command-line runner
+is provided in `run.py` to demonstrate gameplay. The default board now contains
+48 spaces to better mirror the layout of the physical game.
+
+## Installation
+
+Install the package in editable mode using `pip`:
+
+```bash
+pip install -e .
+```
+
+This will make the `cashflow` package available on your system.
+
+## Running the Example
+
+Run the example game with:
+
+```bash
+python run.py
+```
+
+This will simulate turns for two sample players until one reaches
+$50,000 in cash.
+
+During play, landing on certain spaces may grant assets that provide extra
+income each turn or liabilities that increase a player's expenses.
+
+You can customize the game using command-line options. For example:
+
+```bash
+python run.py --players Alice,Bob,Charlie --cash 1500 --rounds 30
+```
+
+This launches a 30-round game for three players starting with $1,500 each.
+
+## Running Tests
+
+The project uses `pytest` for its test suite. Execute the tests from the
+repository root:
+
+```bash
+pytest
+```
+
+## Contributing
+
+Install development dependencies and run the tests before submitting changes:
+
+```bash
+pip install -e .[dev]
+pytest
+```

--- a/cashflow/__init__.py
+++ b/cashflow/__init__.py
@@ -1,0 +1,5 @@
+"""CashFlow game engine package."""
+
+from .engine import Game, Board, Player, SpaceType, Asset, Liability
+
+__all__ = ["Game", "Board", "Player", "SpaceType", "Asset", "Liability"]

--- a/cashflow/engine.py
+++ b/cashflow/engine.py
@@ -1,0 +1,182 @@
+"""Simple game engine for a Cashflow board game clone."""
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+import random
+from typing import List, Optional
+
+
+class SpaceType(Enum):
+    PAYCHECK = auto()
+    DOODAD = auto()
+    DEAL = auto()
+    MARKET = auto()
+    CHARITY = auto()
+    DOWNSIZED = auto()
+    BABY = auto()
+    OPPORTUNITY = auto()
+
+
+@dataclass
+class Space:
+    idx: int
+    type: SpaceType
+
+
+@dataclass
+class Asset:
+    name: str
+    income: int
+
+
+@dataclass
+class Liability:
+    name: str
+    expense: int
+
+
+@dataclass
+class Player:
+    name: str
+    cash: int = 0
+    income: int = 0
+    expenses: int = 0
+    assets: List[Asset] = field(default_factory=list)
+    liabilities: List[Liability] = field(default_factory=list)
+    position: int = 0
+
+    def net_cashflow(self) -> int:
+        asset_income = sum(a.income for a in self.assets)
+        liability_cost = sum(l.expense for l in self.liabilities)
+        return self.income + asset_income - (self.expenses + liability_cost)
+
+
+class Board:
+    def __init__(self, spaces: Optional[List[Space]] = None):
+        if spaces is None:
+            spaces = self._default_board()
+        self.spaces = spaces
+
+    @staticmethod
+    def _default_board() -> List[Space]:
+        # The real Cashflow board contains many more spaces than the minimal
+        # prototype, so here we expand the default layout to 48 spaces.  This
+        # list loosely mirrors the distribution of special spaces found on the
+        # actual board, providing a mix of paychecks, deals and random events.
+
+        base_layout = [
+            Space(0, SpaceType.PAYCHECK),
+            Space(1, SpaceType.DEAL),
+            Space(2, SpaceType.DOODAD),
+            Space(3, SpaceType.MARKET),
+            Space(4, SpaceType.DEAL),
+            Space(5, SpaceType.PAYCHECK),
+            Space(6, SpaceType.DOODAD),
+            Space(7, SpaceType.CHARITY),
+            Space(8, SpaceType.DEAL),
+            Space(9, SpaceType.MARKET),
+            Space(10, SpaceType.DOODAD),
+            Space(11, SpaceType.PAYCHECK),
+            Space(12, SpaceType.DEAL),
+            Space(13, SpaceType.DOWNSIZED),
+            Space(14, SpaceType.DEAL),
+            Space(15, SpaceType.OPPORTUNITY),
+            Space(16, SpaceType.PAYCHECK),
+            Space(17, SpaceType.DEAL),
+            Space(18, SpaceType.MARKET),
+            Space(19, SpaceType.DOODAD),
+            Space(20, SpaceType.DEAL),
+            Space(21, SpaceType.BABY),
+            Space(22, SpaceType.PAYCHECK),
+            Space(23, SpaceType.DEAL),
+            Space(24, SpaceType.DOODAD),
+            Space(25, SpaceType.MARKET),
+            Space(26, SpaceType.DEAL),
+            Space(27, SpaceType.PAYCHECK),
+            Space(28, SpaceType.DOODAD),
+            Space(29, SpaceType.CHARITY),
+            Space(30, SpaceType.DEAL),
+            Space(31, SpaceType.MARKET),
+            Space(32, SpaceType.DOODAD),
+            Space(33, SpaceType.PAYCHECK),
+            Space(34, SpaceType.DEAL),
+            Space(35, SpaceType.DOWNSIZED),
+            Space(36, SpaceType.DEAL),
+            Space(37, SpaceType.OPPORTUNITY),
+            Space(38, SpaceType.PAYCHECK),
+            Space(39, SpaceType.DEAL),
+            Space(40, SpaceType.MARKET),
+            Space(41, SpaceType.DOODAD),
+            Space(42, SpaceType.DEAL),
+            Space(43, SpaceType.BABY),
+            Space(44, SpaceType.DEAL),
+            Space(45, SpaceType.PAYCHECK),
+            Space(46, SpaceType.MARKET),
+            Space(47, SpaceType.DOODAD),
+        ]
+
+        layout = base_layout
+        return layout
+
+    def space_count(self) -> int:
+        return len(self.spaces)
+
+
+class Game:
+    def __init__(self, players: List[Player], board: Optional[Board] = None, die_sides: int = 6):
+        self.players = players
+        self.board = board or Board()
+        self.die_sides = die_sides
+        self.current_player_idx = 0
+        self.random = random.Random()
+
+    def roll_die(self) -> int:
+        return self.random.randint(1, self.die_sides)
+
+    def move_player(self, player: Player, steps: int):
+        player.position = (player.position + steps) % self.board.space_count()
+        space = self.board.spaces[player.position]
+        self.handle_space(player, space)
+
+    def handle_space(self, player: Player, space: Space):
+        if space.type == SpaceType.PAYCHECK:
+            player.cash += player.net_cashflow()
+        elif space.type == SpaceType.DOODAD:
+            cost = self.random.randint(100, 500)
+            player.cash -= cost
+        elif space.type == SpaceType.DEAL:
+            investment = self.random.randint(1000, 4000)
+            income = self.random.randint(100, 300)
+            if player.cash >= investment:
+                player.cash -= investment
+                player.assets.append(Asset(f"Deal {investment}", income))
+        elif space.type == SpaceType.MARKET:
+            if player.assets:
+                player.assets.pop()
+        elif space.type == SpaceType.CHARITY:
+            donation = min(100, player.cash)
+            player.cash -= donation
+        elif space.type == SpaceType.DOWNSIZED:
+            player.cash -= player.expenses * 2
+        elif space.type == SpaceType.BABY:
+            player.liabilities.append(Liability("Baby", 50))
+        elif space.type == SpaceType.OPPORTUNITY:
+            investment = self.random.randint(2000, 6000)
+            income = self.random.randint(200, 500)
+            if player.cash >= investment:
+                player.cash -= investment
+                player.assets.append(Asset(f"Opportunity {investment}", income))
+
+    def next_turn(self):
+        player = self.players[self.current_player_idx]
+        steps = self.roll_die()
+        self.move_player(player, steps)
+        self.current_player_idx = (self.current_player_idx + 1) % len(self.players)
+
+    def is_finished(self) -> bool:
+        return any(p.cash >= 50000 for p in self.players)
+
+    def play_round(self):
+        for _ in range(len(self.players)):
+            self.next_turn()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "cashflow"
+version = "0.1.0"
+description = "A simple game engine for a Cashflow-style board game"
+authors = [{name = "CashFlow Authors", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+dev = ["pytest"]

--- a/run.py
+++ b/run.py
@@ -1,0 +1,50 @@
+import time
+import argparse
+from cashflow.engine import Game, Player
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a CashFlow game")
+    parser.add_argument(
+        "--players",
+        default="Alice,Bob",
+        help="Comma-separated list of player names",
+    )
+    parser.add_argument(
+        "--cash",
+        type=int,
+        default=1000,
+        help="Starting cash for each player",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=50,
+        help="Maximum rounds to play",
+    )
+    args = parser.parse_args()
+
+    names = [n.strip() for n in args.players.split(",") if n.strip()]
+    players = [
+        Player(name=n, cash=args.cash, income=1000, expenses=800) for n in names
+    ]
+
+    game = Game(players)
+
+    round_counter = 0
+    while not game.is_finished() and round_counter < args.rounds:
+        game.play_round()
+        round_counter += 1
+        for p in players:
+            print(
+                f"{p.name}: cash={p.cash}, position={p.position}, assets={len(p.assets)}, liabilities={len(p.liabilities)}"
+            )
+        print("---")
+        time.sleep(0.1)
+
+    winner = max(players, key=lambda p: p.cash)
+    print(f"Winner is {winner.name} with cash {winner.cash}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,46 @@
+import random
+import pytest
+
+from cashflow.engine import Game, Player, Board, Space, SpaceType, Asset, Liability
+
+
+def test_default_board_setup():
+    board = Board()
+    assert board.space_count() == 48
+
+def test_play_round_updates_state():
+    players = [
+        Player(name="Alice", cash=1000, income=1000, expenses=800),
+        Player(name="Bob", cash=1000, income=1500, expenses=1200),
+    ]
+    game = Game(players)
+    game.random.seed(0)
+    game.play_round()
+    assert players[0].position == 4
+    assert players[1].position == 3
+    assert players[0].cash == 1000
+    assert players[1].cash == 1000
+
+def test_winning_condition():
+    players = [
+        Player(name="Alice", cash=51000, income=0, expenses=0),
+        Player(name="Bob", cash=0, income=0, expenses=0),
+    ]
+    game = Game(players)
+    assert game.is_finished()
+
+
+def test_asset_income_and_liability_expense():
+    player = Player(name="Test", income=1000, expenses=500)
+    player.assets.append(Asset("House", income=200))
+    player.liabilities.append(Liability("Loan", expense=75))
+    assert player.net_cashflow() == 1000 + 200 - (500 + 75)
+
+
+def test_baby_space_adds_liability():
+    player = Player(name="Parent", cash=1000, income=1000, expenses=500)
+    board = Board([Space(0, SpaceType.BABY)])
+    game = Game([player], board)
+    game.move_player(player, 1)
+    assert len(player.liabilities) == 1
+    assert player.liabilities[0].expense == 50


### PR DESCRIPTION
## Summary
- implement a larger 48-space board in the engine
- update README to mention expanded board
- adjust board size test for new layout

## Testing
- `python -m py_compile cashflow/engine.py run.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421d24e6788326a50fcd81f65ad308