### PR TITLE
Improve game loop with charity bonus & downsized skipping

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The CashFlow Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# CashFlow
+# CashFlow Game Engine
+
+This repository contains a very small Python implementation of a game engine
+for a board-game clone inspired by Robert Kiyosaki's **Cashflow**.
+
+The engine is located in the `cashflow` package. A simple command-line runner
+is provided in `run.py` to demonstrate gameplay. The default board now contains
+48 spaces to better mirror the layout of the physical game.
+
+## Installation
+
+Install the package in editable mode using `pip`:
+
+```bash
+pip install -e .
+```
+
+This will make the `cashflow` package available on your system.
+
+## Running the Example
+
+Run the example game with:
+
+```bash
+python run.py
+```
+
+This will simulate turns for two sample players until one reaches
+$50,000 in cash.
+
+During play, landing on certain spaces draws from card decks that represent
+deals, doodads, and market events. Deal cards may add new assets if you can
+afford the purchase, doodad cards trigger immediate expenses, and market cards
+can grant cash, add liabilities, or force you to lose an asset. These effects
+combine with your existing assets and liabilities to modify your net cashflow
+each turn. At each paycheck, the game will automatically attempt to pay off the
+oldest liability if you have enough cash to cover its payoff amount. A player
+wins when either their cash reaches $50,000 or their passive income from
+assets meets or exceeds their total expenses.
+
+You can customize the game using command-line options. For example:
+
+```bash
+python run.py --players Alice,Bob,Charlie --cash 1500 --rounds 30 --delay 0
+```
+
+This launches a 30-round game for three players starting with $1,500 each and
+no delay between rounds.
+
+During play the script prints a log message for every turn showing the dice
+roll, new position and space type before displaying each player's updated cash
+and assets.
+
+## Running Tests
+
+The project uses `pytest` for its test suite. Execute the tests from the
+repository root:
+
+```bash
+pytest
+```
+
+## Contributing
+
+Install development dependencies and run the tests before submitting changes:
+
+```bash
+pip install -e .[dev]
+pytest
+```

--- a/cashflow/__init__.py
+++ b/cashflow/__init__.py
@@ -1,0 +1,27 @@
+"""CashFlow game engine package."""
+
+from .engine import (
+    Game,
+    Board,
+    Player,
+    SpaceType,
+    Asset,
+    Liability,
+    DealCard,
+    DoodadCard,
+    MarketCard,
+    Deck,
+)
+
+__all__ = [
+    "Game",
+    "Board",
+    "Player",
+    "SpaceType",
+    "Asset",
+    "Liability",
+    "DealCard",
+    "DoodadCard",
+    "MarketCard",
+    "Deck",
+]

--- a/cashflow/engine.py
+++ b/cashflow/engine.py
@@ -1,0 +1,318 @@
+"""Simple game engine for a Cashflow board game clone."""
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+import random
+from typing import List, Optional
+
+
+class SpaceType(Enum):
+    PAYCHECK = auto()
+    DOODAD = auto()
+    DEAL = auto()
+    MARKET = auto()
+    CHARITY = auto()
+    DOWNSIZED = auto()
+    BABY = auto()
+    OPPORTUNITY = auto()
+
+
+@dataclass
+class Space:
+    idx: int
+    type: SpaceType
+
+
+@dataclass
+class Asset:
+    name: str
+    income: int
+
+
+@dataclass
+class Liability:
+    name: str
+    expense: int
+    payoff: int = 0
+
+
+@dataclass
+class DealCard:
+    """Card representing a potential investment."""
+    name: str
+    cost: int
+    income: int
+
+
+@dataclass
+class DoodadCard:
+    """Card representing an immediate expense."""
+    name: str
+    expense: int
+
+
+@dataclass
+class MarketCard:
+    """Card representing a market event."""
+    name: str
+    effect: str  # 'lose_asset', 'gain_cash', or 'liability'
+    amount: int = 0
+    expense: int = 0
+
+
+class Deck:
+    """Simple deck that returns a random card when drawn."""
+
+    def __init__(self, cards: List):
+        self.cards = list(cards)
+
+    def draw(self, rng: random.Random):
+        return rng.choice(self.cards)
+
+@dataclass
+class Player:
+    name: str
+    cash: int = 0
+    income: int = 0
+    expenses: int = 0
+    assets: List[Asset] = field(default_factory=list)
+    liabilities: List[Liability] = field(default_factory=list)
+    position: int = 0
+    skip_turns: int = 0
+    extra_dice_turns: int = 0
+
+    def net_cashflow(self) -> int:
+        asset_income = sum(a.income for a in self.assets)
+        liability_cost = sum(l.expense for l in self.liabilities)
+        return self.income + asset_income - (self.expenses + liability_cost)
+
+    def passive_income(self) -> int:
+        return sum(a.income for a in self.assets)
+
+    def total_expenses(self) -> int:
+        return self.expenses + sum(l.expense for l in self.liabilities)
+
+    def pay_off_liability(self, index: int) -> bool:
+        if 0 <= index < len(self.liabilities):
+            liability = self.liabilities[index]
+            if self.cash >= liability.payoff:
+                self.cash -= liability.payoff
+                self.liabilities.pop(index)
+                return True
+        return False
+
+
+class Board:
+    def __init__(self, spaces: Optional[List[Space]] = None):
+        if spaces is None:
+            spaces = self._default_board()
+        self.spaces = spaces
+
+    @staticmethod
+    def _default_board() -> List[Space]:
+        # The real Cashflow board contains many more spaces than the minimal
+        # prototype, so here we expand the default layout to 48 spaces.  This
+        # list loosely mirrors the distribution of special spaces found on the
+        # actual board, providing a mix of paychecks, deals and random events.
+
+        base_layout = [
+            Space(0, SpaceType.PAYCHECK),
+            Space(1, SpaceType.DEAL),
+            Space(2, SpaceType.DOODAD),
+            Space(3, SpaceType.MARKET),
+            Space(4, SpaceType.DEAL),
+            Space(5, SpaceType.PAYCHECK),
+            Space(6, SpaceType.DOODAD),
+            Space(7, SpaceType.CHARITY),
+            Space(8, SpaceType.DEAL),
+            Space(9, SpaceType.MARKET),
+            Space(10, SpaceType.DOODAD),
+            Space(11, SpaceType.PAYCHECK),
+            Space(12, SpaceType.DEAL),
+            Space(13, SpaceType.DOWNSIZED),
+            Space(14, SpaceType.DEAL),
+            Space(15, SpaceType.OPPORTUNITY),
+            Space(16, SpaceType.PAYCHECK),
+            Space(17, SpaceType.DEAL),
+            Space(18, SpaceType.MARKET),
+            Space(19, SpaceType.DOODAD),
+            Space(20, SpaceType.DEAL),
+            Space(21, SpaceType.BABY),
+            Space(22, SpaceType.PAYCHECK),
+            Space(23, SpaceType.DEAL),
+            Space(24, SpaceType.DOODAD),
+            Space(25, SpaceType.MARKET),
+            Space(26, SpaceType.DEAL),
+            Space(27, SpaceType.PAYCHECK),
+            Space(28, SpaceType.DOODAD),
+            Space(29, SpaceType.CHARITY),
+            Space(30, SpaceType.DEAL),
+            Space(31, SpaceType.MARKET),
+            Space(32, SpaceType.DOODAD),
+            Space(33, SpaceType.PAYCHECK),
+            Space(34, SpaceType.DEAL),
+            Space(35, SpaceType.DOWNSIZED),
+            Space(36, SpaceType.DEAL),
+            Space(37, SpaceType.OPPORTUNITY),
+            Space(38, SpaceType.PAYCHECK),
+            Space(39, SpaceType.DEAL),
+            Space(40, SpaceType.MARKET),
+            Space(41, SpaceType.DOODAD),
+            Space(42, SpaceType.DEAL),
+            Space(43, SpaceType.BABY),
+            Space(44, SpaceType.DEAL),
+            Space(45, SpaceType.PAYCHECK),
+            Space(46, SpaceType.MARKET),
+            Space(47, SpaceType.DOODAD),
+        ]
+
+        layout = base_layout
+        return layout
+
+    def space_count(self) -> int:
+        return len(self.spaces)
+
+
+def _default_deal_cards() -> List[DealCard]:
+    return [
+        DealCard("Condo", cost=1000, income=100),
+        DealCard("Car Wash", cost=2000, income=150),
+        DealCard("Retail Shop", cost=3000, income=250),
+    ]
+
+
+def _default_big_deal_cards() -> List[DealCard]:
+    return [
+        DealCard("Apartment Building", cost=6000, income=600),
+        DealCard("Storage Units", cost=8000, income=750),
+    ]
+
+
+def _default_doodad_cards() -> List[DoodadCard]:
+    return [
+        DoodadCard("New Phone", expense=100),
+        DoodadCard("Vacation", expense=400),
+        DoodadCard("Gadget", expense=250),
+    ]
+
+
+def _default_market_cards() -> List[MarketCard]:
+    return [
+        MarketCard("Economic Boom", effect="gain_cash", amount=500),
+        MarketCard("Property Tax", effect="liability", expense=150),
+        MarketCard("Storm Damage", effect="lose_asset"),
+    ]
+
+
+class Game:
+    def __init__(
+        self,
+        players: List[Player],
+        board: Optional[Board] = None,
+        die_sides: int = 6,
+        deal_deck: Optional[Deck] = None,
+        big_deal_deck: Optional[Deck] = None,
+        doodad_deck: Optional[Deck] = None,
+        market_deck: Optional[Deck] = None,
+    ):
+        self.players = players
+        self.board = board or Board()
+        self.die_sides = die_sides
+        self.current_player_idx = 0
+        self.random = random.Random()
+        self.deal_deck = deal_deck or Deck(_default_deal_cards())
+        self.big_deal_deck = big_deal_deck or Deck(_default_big_deal_cards())
+        self.doodad_deck = doodad_deck or Deck(_default_doodad_cards())
+        self.market_deck = market_deck or Deck(_default_market_cards())
+
+    def roll_die(self, player: Player) -> int:
+        """Roll one or two dice depending on player's bonus state."""
+        if player.extra_dice_turns > 0:
+            player.extra_dice_turns -= 1
+            return self.random.randint(1, self.die_sides) + self.random.randint(1, self.die_sides)
+        return self.random.randint(1, self.die_sides)
+
+    def move_player(self, player: Player, steps: int) -> Space:
+        """Move ``player`` forward ``steps`` spaces and handle the landing space.
+
+        Returns the ``Space`` landed on so callers can report what happened.
+        """
+        player.position = (player.position + steps) % self.board.space_count()
+        space = self.board.spaces[player.position]
+        self.handle_space(player, space)
+        return space
+
+    def handle_space(self, player: Player, space: Space):
+        if space.type == SpaceType.PAYCHECK:
+            player.cash += player.net_cashflow()
+            if player.liabilities:
+                # attempt to pay off the first liability if affordable
+                player.pay_off_liability(0)
+        elif space.type == SpaceType.DOODAD:
+            card = self.doodad_deck.draw(self.random)
+            player.cash -= card.expense
+        elif space.type == SpaceType.DEAL:
+            card = self.deal_deck.draw(self.random)
+            if player.cash >= card.cost:
+                player.cash -= card.cost
+                player.assets.append(Asset(card.name, card.income))
+        elif space.type == SpaceType.MARKET:
+            card = self.market_deck.draw(self.random)
+            if card.effect == "lose_asset":
+                if player.assets:
+                    player.assets.pop()
+            elif card.effect == "gain_cash":
+                player.cash += card.amount
+            elif card.effect == "liability":
+                payoff = card.expense * 10
+                player.liabilities.append(Liability(card.name, card.expense, payoff))
+        elif space.type == SpaceType.CHARITY:
+            donation = min(100, player.cash)
+            player.cash -= donation
+            player.extra_dice_turns = 3
+        elif space.type == SpaceType.DOWNSIZED:
+            player.cash -= player.expenses * 2
+            player.skip_turns = 2
+        elif space.type == SpaceType.BABY:
+            player.liabilities.append(Liability("Baby", 50, payoff=500))
+        elif space.type == SpaceType.OPPORTUNITY:
+            card = self.big_deal_deck.draw(self.random)
+            if player.cash >= card.cost:
+                player.cash -= card.cost
+                player.assets.append(Asset(card.name, card.income))
+
+    def next_turn(self) -> str:
+        """Advance the game by one turn for the current player.
+
+        Returns a short string describing the action taken so a caller can
+        display it in a user interface.
+        """
+        player = self.players[self.current_player_idx]
+        description = ""
+        if player.skip_turns > 0:
+            player.skip_turns -= 1
+            description = f"{player.name} is downsized and must skip a turn."
+        else:
+            steps = self.roll_die(player)
+            start = player.position
+            space = self.move_player(player, steps)
+            description = (
+                f"{player.name} rolled {steps} moving from {start} to "
+                f"{player.position} ({space.type.name})."
+            )
+        self.current_player_idx = (self.current_player_idx + 1) % len(self.players)
+        return description
+
+    def is_finished(self) -> bool:
+        return any(
+            p.cash >= 50000 or p.passive_income() >= p.total_expenses()
+            for p in self.players
+        )
+
+    def play_round(self) -> List[str]:
+        """Play a complete round and return log messages for each turn."""
+        logs: List[str] = []
+        for _ in range(len(self.players)):
+            logs.append(self.next_turn())
+        return logs
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "cashflow"
+version = "0.1.0"
+description = "A simple game engine for a Cashflow-style board game"
+authors = [{name = "CashFlow Authors", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+dev = ["pytest"]

--- a/run.py
+++ b/run.py
@@ -1,0 +1,72 @@
+import time
+import argparse
+from cashflow.engine import Game, Player
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a CashFlow game")
+    parser.add_argument(
+        "--players",
+        default="Alice,Bob",
+        help="Comma-separated list of player names",
+    )
+    parser.add_argument(
+        "--cash",
+        type=int,
+        default=1000,
+        help="Starting cash for each player",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=50,
+        help="Maximum rounds to play",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=0.2,
+        help="Seconds to wait between rounds",
+    )
+    args = parser.parse_args()
+
+    names = [n.strip() for n in args.players.split(",") if n.strip()]
+    players = [
+        Player(name=n, cash=args.cash, income=1000, expenses=800) for n in names
+    ]
+
+    game = Game(players)
+
+    def fmt_assets(p: Player) -> str:
+        if not p.assets:
+            return "none"
+        return ", ".join(f"{a.name} (${a.income})" for a in p.assets)
+
+    def fmt_liabs(p: Player) -> str:
+        if not p.liabilities:
+            return "none"
+        return ", ".join(f"{l.name} (${l.expense})" for l in p.liabilities)
+
+    print("Players:")
+    for p in players:
+        print(f"  {p.name} starting with ${p.cash}")
+
+    round_counter = 0
+    while not game.is_finished() and round_counter < args.rounds:
+        print(f"\n=== Round {round_counter + 1} ===")
+        logs = game.play_round()
+        for log in logs:
+            print(log)
+        for p in players:
+            print(
+                f"{p.name}: cash=${p.cash}, pos={p.position}, assets={fmt_assets(p)}, liabilities={fmt_liabs(p)}"
+            )
+        round_counter += 1
+        time.sleep(args.delay)
+
+    winner = max(players, key=lambda p: p.cash)
+    print(f"Winner is {winner.name} with cash {winner.cash}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,133 @@
+import random
+import pytest
+
+from cashflow.engine import (
+    Game,
+    Player,
+    Board,
+    Space,
+    SpaceType,
+    Asset,
+    Liability,
+    Deck,
+    DealCard,
+    DoodadCard,
+    MarketCard,
+)
+
+
+def test_default_board_setup():
+    board = Board()
+    assert board.space_count() == 48
+
+def test_play_round_updates_state():
+    players = [
+        Player(name="Alice", cash=1000, income=1000, expenses=800),
+        Player(name="Bob", cash=1000, income=1500, expenses=1200),
+    ]
+    game = Game(players)
+    game.random.seed(0)
+    game.play_round()
+    assert players[0].position == 4
+    assert players[1].position == 1
+    assert players[0].cash == 1000
+    assert players[1].cash == 1000
+
+def test_winning_condition():
+    players = [
+        Player(name="Alice", cash=51000, income=0, expenses=0),
+        Player(name="Bob", cash=0, income=0, expenses=0),
+    ]
+    game = Game(players)
+    assert game.is_finished()
+
+
+def test_asset_income_and_liability_expense():
+    player = Player(name="Test", income=1000, expenses=500)
+    player.assets.append(Asset("House", income=200))
+    player.liabilities.append(Liability("Loan", expense=75, payoff=500))
+    assert player.net_cashflow() == 1000 + 200 - (500 + 75)
+
+
+def test_baby_space_adds_liability():
+    player = Player(name="Parent", cash=1000, income=1000, expenses=500)
+    board = Board([Space(0, SpaceType.BABY)])
+    game = Game([player], board)
+    game.move_player(player, 1)
+    assert len(player.liabilities) == 1
+    assert player.liabilities[0].expense == 50
+
+
+def test_deal_card_adds_asset():
+    player = Player(name="Investor", cash=2000)
+    deal_deck = Deck([DealCard("Test Deal", cost=1000, income=100)])
+    board = Board([Space(0, SpaceType.DEAL)])
+    game = Game([player], board, deal_deck=deal_deck)
+    game.move_player(player, 1)
+    assert player.cash == 1000
+    assert len(player.assets) == 1
+    assert player.assets[0].income == 100
+
+
+def test_doodad_card_reduces_cash():
+    player = Player(name="Shopper", cash=1000)
+    doodad_deck = Deck([DoodadCard("Test Doodad", expense=300)])
+    board = Board([Space(0, SpaceType.DOODAD)])
+    game = Game([player], board, doodad_deck=doodad_deck)
+    game.move_player(player, 1)
+    assert player.cash == 700
+
+
+def test_market_card_grants_cash():
+    player = Player(name="Trader", cash=500)
+    market_deck = Deck([MarketCard("Bonus", effect="gain_cash", amount=200)])
+    board = Board([Space(0, SpaceType.MARKET)])
+    game = Game([player], board, market_deck=market_deck)
+    game.move_player(player, 1)
+    assert player.cash == 700
+
+
+def test_pay_off_liability():
+    player = Player(name="Debtor", cash=1000, income=0, expenses=0)
+    player.liabilities.append(Liability("Car Loan", expense=50, payoff=300))
+    board = Board([Space(0, SpaceType.PAYCHECK)])
+    game = Game([player], board)
+    game.move_player(player, 1)
+    assert player.cash == 650
+    assert not player.liabilities
+
+
+def test_winning_condition_passive_income():
+    player = Player(name="Investor", cash=0, income=0, expenses=500)
+    player.assets.append(Asset("Rental", income=600))
+    game = Game([player])
+    assert game.is_finished()
+
+
+def test_charity_grants_extra_dice():
+    player = Player(name="Charitable", cash=1000)
+    board = Board([Space(0, SpaceType.CHARITY), Space(1, SpaceType.PAYCHECK)])
+    game = Game([player], board)
+    game.random.seed(0)
+    game.next_turn()  # land on charity
+    assert player.cash == 900
+    assert player.extra_dice_turns == 3
+    game.next_turn()  # should roll two dice (4 + 1 = 5)
+    assert player.position == 1
+    assert player.extra_dice_turns == 2
+
+
+def test_downsized_skips_turns():
+    player = Player(name="Worker", cash=1000, income=1000, expenses=500)
+    board = Board([Space(0, SpaceType.DOWNSIZED), Space(1, SpaceType.PAYCHECK)])
+    game = Game([player], board)
+    game.random.seed(0)
+    game.next_turn()  # land on downsized
+    assert player.cash == 0
+    assert player.skip_turns == 2
+    game.next_turn()  # skipped turn
+    assert player.position == 0
+    assert player.skip_turns == 1
+    game.next_turn()  # skipped turn
+    assert player.position == 0
+    assert player.skip_turns == 0


### PR DESCRIPTION
## Summary
- add `skip_turns` and `extra_dice_turns` to `Player`
- implement variable dice rolls and skipped turns
- update charity and downsized spaces to trigger new behaviour
- extend tests for charity bonus and downsizing
- improve CLI output with per-turn log messages and delay option

## Testing
- `python -m py_compile cashflow/engine.py run.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421d24e6788326a50fcd81f65ad308